### PR TITLE
🧹 Remove console.log from production code in googleDrive.ts

### DIFF
--- a/src/lib/googleDrive.ts
+++ b/src/lib/googleDrive.ts
@@ -87,9 +87,7 @@ export const createFile = (content: string, fileName: string) => {
       media: media,
       fields: 'id',
     })
-    .then((response) => {
-      console.log('File ID:', response.result.id);
-    });
+    .then();
 };
 
 export const openFilePicker = (callback: (doc: any) => void) => {


### PR DESCRIPTION
Removed a console.log statement in src/lib/googleDrive.ts. The .then() call was preserved to ensure the Google API request is actually dispatched, as gapi.client requests are lazy thenables.

---
*PR created automatically by Jules for task [13962947138705996681](https://jules.google.com/task/13962947138705996681) started by @lksmxer*