### PR TITLE
🧹 Replace 'any' type for user state

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -6,12 +6,12 @@ import { Button } from '@/components/ui/button';
 import { initClient, initGis, handleAuthClick, handleSignoutClick } from '@/lib/googleDrive';
 
 interface LayoutProps {
-  children: (user: any) => React.ReactNode;
+  children: (user: google.accounts.oauth2.TokenResponse | null) => React.ReactNode;
   className?: string;
 }
 
 const Layout: React.FC<LayoutProps> = ({ children, className }) => {
-  const [user, setUser] = useState<any>(null);
+  const [user, setUser] = useState<google.accounts.oauth2.TokenResponse | null>(null);
 
   useEffect(() => {
     initClient(() => {

--- a/src/components/WorkoutForm.tsx
+++ b/src/components/WorkoutForm.tsx
@@ -15,7 +15,7 @@ interface WorkoutFormProps {
   workout: Workout;
   onWorkoutChange: (workout: Workout) => void;
   onImport: () => void;
-  user: any;
+  user: google.accounts.oauth2.TokenResponse | null;
 }
 
 const WorkoutForm: React.FC<WorkoutFormProps> = ({ workout, onWorkoutChange, onImport, user }) => {


### PR DESCRIPTION
### 🎯 What
Replaced the `any` type for the `user` state and prop with the specific `google.accounts.oauth2.TokenResponse | null` type in `Layout.tsx` and `WorkoutForm.tsx`.

### 💡 Why
Using `any` hides potential type errors and makes the codebase harder to maintain. Typing the user state appropriately improves type safety and developer experience when working with the Google Drive integration.

### ✅ Verification
- Manually verified the changes in `src/components/Layout.tsx` and `src/components/WorkoutForm.tsx`.
- Ran `bun test` to ensure existing utility tests pass.
- Code review confirmed the changes are correct and follow codebase conventions.

### ✨ Result
Improved type safety for the user authentication state throughout the application.

---
*PR created automatically by Jules for task [9618546446685214043](https://jules.google.com/task/9618546446685214043) started by @lksmxer*