### PR TITLE
🧪 [testing improvement] Add tests for toast reducer

### DIFF
--- a/src/hooks/use-toast.test.ts
+++ b/src/hooks/use-toast.test.ts
@@ -1,0 +1,114 @@
+
+import { expect, test, describe } from "bun:test";
+import { reducer, actionTypes, TOAST_LIMIT, type State, type ToasterToast } from "./use-toast";
+
+describe("toast reducer", () => {
+  const initialState: State = { toasts: [] };
+
+  describe("ADD_TOAST", () => {
+    test("should add a toast to the state", () => {
+      const toast: ToasterToast = { id: "1", title: "Test Toast", open: true };
+      const action = { type: actionTypes.ADD_TOAST, toast };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.toasts).toHaveLength(1);
+      expect(newState.toasts[0]).toEqual(toast);
+    });
+
+    test("should respect TOAST_LIMIT", () => {
+      const toast1: ToasterToast = { id: "1", title: "Toast 1" };
+      const toast2: ToasterToast = { id: "2", title: "Toast 2" };
+
+      let state = reducer(initialState, { type: actionTypes.ADD_TOAST, toast: toast1 });
+      state = reducer(state, { type: actionTypes.ADD_TOAST, toast: toast2 });
+
+      expect(state.toasts).toHaveLength(TOAST_LIMIT);
+      expect(state.toasts[0]).toEqual(toast2); // Newest should be first and stay
+    });
+  });
+
+  describe("UPDATE_TOAST", () => {
+    test("should update an existing toast", () => {
+      const toast: ToasterToast = { id: "1", title: "Old Title" };
+      const state = { toasts: [toast] };
+
+      const updatedToast = { id: "1", title: "New Title" };
+      const action = { type: actionTypes.UPDATE_TOAST, toast: updatedToast };
+
+      const newState = reducer(state, action);
+
+      expect(newState.toasts[0].title).toBe("New Title");
+    });
+
+    test("should not update if ID does not match", () => {
+      const toast: ToasterToast = { id: "1", title: "Title" };
+      const state = { toasts: [toast] };
+
+      const action = { type: actionTypes.UPDATE_TOAST, toast: { id: "2", title: "New Title" } };
+
+      const newState = reducer(state, action);
+
+      expect(newState.toasts[0].title).toBe("Title");
+    });
+  });
+
+  describe("DISMISS_TOAST", () => {
+    test("should set open: false for a specific toast", () => {
+      const toast: ToasterToast = { id: "1", title: "Toast", open: true };
+      const state = { toasts: [toast] };
+
+      const action = { type: actionTypes.DISMISS_TOAST, toastId: "1" };
+      const newState = reducer(state, action);
+
+      expect(newState.toasts[0].open).toBe(false);
+    });
+
+    test("should set open: false for all toasts if no toastId provided", () => {
+      const state = {
+        toasts: [
+          { id: "1", title: "Toast 1", open: true },
+          { id: "2", title: "Toast 2", open: true },
+        ]
+      };
+
+      const action = { type: actionTypes.DISMISS_TOAST };
+      const newState = reducer(state, action);
+
+      expect(newState.toasts[0].open).toBe(false);
+      expect(newState.toasts[1].open).toBe(false);
+    });
+
+  });
+
+  describe("REMOVE_TOAST", () => {
+    test("should remove a specific toast by ID", () => {
+      const state = {
+        toasts: [
+          { id: "1", title: "Toast 1" },
+          { id: "2", title: "Toast 2" },
+        ]
+      };
+
+      const action = { type: actionTypes.REMOVE_TOAST, toastId: "1" };
+      const newState = reducer(state, action);
+
+      expect(newState.toasts).toHaveLength(1);
+      expect(newState.toasts[0].id).toBe("2");
+    });
+
+    test("should remove all toasts if no toastId provided", () => {
+      const state = {
+        toasts: [
+          { id: "1", title: "Toast 1" },
+          { id: "2", title: "Toast 2" },
+        ]
+      };
+
+      const action = { type: actionTypes.REMOVE_TOAST };
+      const newState = reducer(state, action);
+
+      expect(newState.toasts).toHaveLength(0);
+    });
+  });
+});

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -5,17 +5,17 @@ import type {
   ToastProps,
 } from "@/components/ui/toast"
 
-const TOAST_LIMIT = 1
+export const TOAST_LIMIT = 1
 const TOAST_REMOVE_DELAY = 1000000
 
-type ToasterToast = ToastProps & {
+export type ToasterToast = ToastProps & {
   id: string
   title?: React.ReactNode
   description?: React.ReactNode
   action?: ToastActionElement
 }
 
-const actionTypes = {
+export const actionTypes = {
   ADD_TOAST: "ADD_TOAST",
   UPDATE_TOAST: "UPDATE_TOAST",
   DISMISS_TOAST: "DISMISS_TOAST",
@@ -29,9 +29,9 @@ function genId() {
   return count.toString()
 }
 
-type ActionType = typeof actionTypes
+export type ActionType = typeof actionTypes
 
-type Action =
+export type Action =
   | {
       type: ActionType["ADD_TOAST"]
       toast: ToasterToast
@@ -49,7 +49,7 @@ type Action =
       toastId?: ToasterToast["id"]
     }
 
-interface State {
+export interface State {
   toasts: ToasterToast[]
 }
 


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the lack of unit tests for the toast reducer in `src/hooks/use-toast.ts`.

📊 **Coverage:** The new test suite in `src/hooks/use-toast.test.ts` covers:
- `ADD_TOAST`: Verifying toast addition and `TOAST_LIMIT` enforcement.
- `UPDATE_TOAST`: Verifying updates to existing toasts.
- `DISMISS_TOAST`: Verifying both specific and bulk dismissal (setting `open: false`).
- `REMOVE_TOAST`: Verifying both specific and bulk removal from state.

✨ **Result:** Improved test coverage and reliability for the application's notification system. State transitions are now verified and protected against regressions.

---
*PR created automatically by Jules for task [17432138755184435129](https://jules.google.com/task/17432138755184435129) started by @lksmxer*